### PR TITLE
Allow enabling displaylink.service

### DIFF
--- a/displaylink.service
+++ b/displaylink.service
@@ -9,3 +9,6 @@ ExecStart=/usr/libexec/displaylink/DisplayLinkManager
 Restart=always
 WorkingDirectory=/usr/libexec/displaylink
 RestartSec=5
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Without the [Install] section, systemd won't be able to enable it.